### PR TITLE
20200426 add nas message

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,3 +1,0 @@
-NAS_LIMIT = 30
-SLACK_BOT_USER_ACCESS_TOKEN = sample_bot_token
-SLACK_OAUTH_ACCESS_TOKEN = sample_oauth_token

--- a/.env_sample
+++ b/.env_sample
@@ -1,1 +1,3 @@
 NAS_LIMIT = 30
+SLACK_BOT_USER_ACCESS_TOKEN = sample_bot_token
+SLACK_OAUTH_ACCESS_TOKEN = sample_oauth_token

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ sphinx-rtd-theme = "*"
 v = {editable = true,version = "*"}
 moto = "*"
 pytest-mock = "*"
+pytest-env = "*"
 
 [packages]
 setuptools = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ sphinx = "*"
 sphinx-rtd-theme = "*"
 v = {editable = true,version = "*"}
 moto = "*"
+pytest-mock = "*"
 
 [packages]
 setuptools = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c6e9dbac3a77b7c729b8e5826c5954d9f2aa7136ed5956d61dcd9b5868c97b79"
+            "sha256": "a0355a9b3a1d97d4f8306b2975161f81e4c2c1c54ed70cdedccc7b1476d5f7b4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -509,6 +509,13 @@
             ],
             "index": "pypi",
             "version": "==5.4.1"
+        },
+        "pytest-env": {
+            "hashes": [
+                "sha256:7e94956aef7f2764f3c147d216ce066bf6c42948bb9e293169b1b1c880a580c2"
+            ],
+            "index": "pypi",
+            "version": "==0.6.2"
         },
         "pytest-mock": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d1abd233fa5464d8bfc9701544dd1e56eb007a70c4474122373313ae0d78cc6f"
+            "sha256": "c6e9dbac3a77b7c729b8e5826c5954d9f2aa7136ed5956d61dcd9b5868c97b79"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -510,6 +510,14 @@
             "index": "pypi",
             "version": "==5.4.1"
         },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:997729451dfc36b851a9accf675488c7020beccda15e11c75632ee3d1b1ccd71",
+                "sha256:ce610831cedeff5331f4e2fc453a5dd65384303f680ab34bee2c6533855b431c"
+            ],
+            "index": "pypi",
+            "version": "==3.1.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
@@ -594,11 +602,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:3145d87d0962366d4c5264c39094eae3f5788d01d4b1a12294051bfe4271d91b",
-                "sha256:d7c6e72c6aa229caf96af82f60a0d286a1521d42496c226fe37f5a75dcfe2941"
+                "sha256:62edfd92d955b868d6c124c0942eba966d54b5f3dcb4ded39e65f74abac3f572",
+                "sha256:f5505d74cf9592f3b997380f9bdb2d2d0320ed74dd69691e3ee0644b956b8d83"
             ],
             "index": "pypi",
-            "version": "==3.0.2"
+            "version": "==3.0.3"
         },
         "sphinx-rtd-theme": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,9 @@ packages = find:
 show_source = True
 max-line-length=140
 max-complexity=15
+
+[tool:pytest]
+env =
+    NAS_LIMIT = 30
+    SLACK_BOT_USER_ACCESS_TOKEN = sample_bot_token
+    SLACK_OAUTH_ACCESS_TOKEN = sample_oauth_token

--- a/src/nas.py
+++ b/src/nas.py
@@ -1,17 +1,17 @@
 # nasクラスを作る。
 import math
 import os
-
-from .db import load_send_nas_num, create_nas_record
-from .utils import get_last_week_ref_timestamp, get_ref_timestamp
-
 from configparser import ConfigParser, ExtendedInterpolation
+
+from .db import create_nas_record, load_send_nas_num
+from .utils import get_last_week_ref_timestamp, get_ref_timestamp
 
 STAMP_CONFIG = ConfigParser(interpolation=ExtendedInterpolation())
 STAMP_CONFIG.read('./src/stamp_config.ini')
 
 
 NAS_LIMIT = int(os.environ['NAS_LIMIT'])
+
 
 class Nas:
     def __init__(self, user_id, user_name, team_id):
@@ -63,4 +63,16 @@ class Nas:
         for i in range(int(send_nas_num)):
             create_nas_record(self.user_id, self.user_name, receive_user_id, receive_user_name, 'stamp', self.team_id)
 
+        return True
+
+    def nas_message(self, receive_user_id, receive_user_name):
+        if self.chack_self_portrait(receive_user_id) is True:
+            print('self_portrait')
+            return False
+
+        if self.check_can_send_nas() is False:
+            print('nas send limit')
+            return False
+
+        create_nas_record(self.user_id, self.user_name, receive_user_id, receive_user_name, 'message', self.team_id)
         return True

--- a/src/send_message.py
+++ b/src/send_message.py
@@ -3,8 +3,6 @@ import os
 
 import requests
 
-os.environ['NAS_LIMIT']
-
 
 def post_public_message_to_slack(send_message, slack_channel_name):
     slack_bot_token = "Bearer {0}".format(os.environ['SLACK_BOT_USER_ACCESS_TOKEN'])

--- a/src/send_message.py
+++ b/src/send_message.py
@@ -1,0 +1,30 @@
+import json
+import os
+
+import requests
+
+os.environ['NAS_LIMIT']
+
+
+def post_public_message_to_slack(send_message, slack_channel_name):
+    slack_bot_token = "Bearer {0}".format(os.environ['SLACK_BOT_USER_ACCESS_TOKEN'])
+    slack_oauth_token = os.environ["SLACK_OAUTH_ACCESS_TOKEN"]
+
+    slack_api_url = "https://slack.com/api/chat.postMessage"
+    headers = {
+        "Content-Type": "application/json; charset=UTF-8",
+        "Authorization": slack_bot_token
+    }
+    data = {
+        "token": slack_oauth_token,
+        "channel": slack_channel_name,
+        "text": send_message
+    }
+    try:
+        response = requests.post(slack_api_url, data=json.dumps(data).encode("utf-8"), headers=headers)
+        if response.status_code != requests.codes.ok:
+            return False
+    except Exception as e:
+        print(e)
+        return False
+    return True

--- a/src/send_message.py
+++ b/src/send_message.py
@@ -26,3 +26,28 @@ def post_public_message_to_slack(send_message, slack_channel_name):
         print(e)
         return False
     return True
+
+
+def post_private_message_to_slack(send_message, slack_channel_name, dist_user_id):
+    slack_bot_token = "Bearer {0}".format(os.environ['SLACK_BOT_USER_ACCESS_TOKEN'])
+    slack_oauth_token = os.environ["SLACK_OAUTH_ACCESS_TOKEN"]
+
+    slack_api_url = "https://slack.com/api/chat.postEphemeral"
+    headers = {
+        "Content-Type": "application/json; charset=UTF-8",
+        "Authorization": slack_bot_token
+    }
+    data = {
+        "token": slack_oauth_token,
+        "channel": slack_channel_name,
+        "text": send_message,
+        "user": dist_user_id
+    }
+    try:
+        response = requests.post(slack_api_url, data=json.dumps(data).encode("utf-8"), headers=headers)
+        if response.status_code != requests.codes.ok:
+            return False
+    except Exception as e:
+        print(e)
+        return False
+    return True

--- a/tests/test_nas.py
+++ b/tests/test_nas.py
@@ -163,3 +163,23 @@ class TestNas():
         assert nas_obj.nas_stamp('test_user_B_id', 'test_user_B_name', 'eggplant') is True
 
         assert nas_obj.nas_stamp('test_user_B_id', 'test_user_B_name', 'some_stamp') is False
+
+    def test_nas_message(self):
+        """Send the NAS with a message.
+        Send the NAS with a message.
+        A method to send a NAS with a prepackaged message using the nas_message command.
+        In this section, we go as far as making a record.
+        Sending a message is done by another function.
+        Therefore, the return value is the bool value of whether the NAS transmission was successful or not.
+
+        Args:
+            receive_user_id: The slack user_id of the destination
+            receive_user_name : The slack user_name of the destination
+
+        Return:
+            bool : is the nas sent successfully. success is True. Fail is False.
+        """
+        nas_obj = Nas('test_user_A_id', 'test_user_A_name', 'test_team_id')
+        assert nas_obj.nas_message('test_user_B_id', 'test_user_B_name') is True
+
+        assert nas_obj.nas_message('test_user_A_id', 'test_user_A_name') is False

--- a/tests/test_send_message.py
+++ b/tests/test_send_message.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import sys
+
+from src.send_message import post_public_message_to_slack
+
+sys.path.append('../')
+
+
+def test_post_public_message_to_slack(mocker):
+    """Sending a public message to a specific channel in Slack
+    You can send a message to the specified Slack channel.
+    You need a slack token to send it. These settings should be done in advance.
+    If you want to have a canary environment in addition to the production environment,
+    you can prepare another room for testing and do a transmission test.
+
+    Args:
+        send_message: slack send message
+        slack_channel_name: send message distination channel name
+
+    Return:
+        bool: send success is True. send failer is False.
+    """
+
+    # Create fake response
+    responseMock = mocker.Mock()
+    responseMock.status_code = 200
+    responseMock.text = 'success'
+
+    mocker.patch('requests.post').return_value = responseMock
+    assert post_public_message_to_slack('sample_massage!', 'sample_channel') is True

--- a/tests/test_send_message.py
+++ b/tests/test_send_message.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from src.send_message import post_public_message_to_slack
+from src.send_message import post_public_message_to_slack, post_private_message_to_slack
 
 sys.path.append('../')
 
@@ -28,3 +28,33 @@ def test_post_public_message_to_slack(mocker):
 
     mocker.patch('requests.post').return_value = responseMock
     assert post_public_message_to_slack('sample_massage!', 'sample_channel') is True
+
+
+def test_post_private_message_to_slack(mocker):
+    """Sending a private message to a specific channel in Slack
+    Send a private message that only the target user can see.
+    You need a slack token to send it. These settings should be done in advance.
+    If you want to have a canary environment in addition to the production environment,
+    you can prepare another room for testing and do a transmission test.
+
+    Args:
+        send_message: slack send message
+        slack_channel_name: send message distination channel name
+        distdist_user_id_user: destination user id
+
+    Return:
+        bool: send success is True. send failer is False.
+    """
+    # Create fake response
+    responseMock = mocker.Mock()
+    responseMock.status_code = 200
+    responseMock.text = 'success'
+
+    mocker.patch('requests.post').return_value = responseMock
+    assert post_private_message_to_slack('sample_massage!', 'sample_channel', 'test_user_A_id') is True
+
+    responseMock.status_code = 404
+    responseMock.text = 'error'
+
+    mocker.patch('requests.post').return_value = responseMock
+    assert post_private_message_to_slack('sample_massage!', 'sample_channel', 'test_user_A_id') is False


### PR DESCRIPTION
## Purpose
Add nas message function.

The ability to send the NAS with a message.
The handling of the processing is implemented in a separate PR. The goal is to get to the point where messages can be sent and NAS records can be created.

## How to implement
- implement nas message command
- implement public/private slack messsage function

## Test trail
- [x] test passed
- [x] can create nas message record in dynamo db
- [x] can send public message on slack
- [x] can send private message on slack

## reference
