### PR TITLE
20200428 add nas ranking

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -20,6 +20,28 @@ def load_send_nas_num(user_id, ref_timestamp):
         return 0
 
 
+def scan_nas_records(ref_timestamp):
+    try:
+        dynamoDB = boto3.resource('dynamodb')
+        table = dynamoDB.Table('NAS')
+
+        response = table.scan(
+            FilterExpression=Key('time_stamp').gt(ref_timestamp)
+        )
+        nas_records = response['Items']
+
+        while 'LastEvaluatedKey' in response:
+            response = table.scan(
+                FilterExpression=Key('time_stamp').gt(ref_timestamp),
+                ExclusiveStartKey=response['LastEvaluatedKey']
+            )
+            nas_records.extend(response['Items'])
+        return nas_records
+    except Exception as e:
+        print(e)
+        return []
+
+
 def create_nas_record(nas_user_id, nas_user_name, receive_user_id, receive_user_name, nas_type, team_id):
     try:
         dynamoDB = boto3.resource('dynamodb')

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
+from .db import scan_nas_records
+from collections import Counter
 
 import pytz
 
@@ -23,3 +25,19 @@ def get_last_week_ref_timestamp():
     format_ref_date = datetime(now.year, now.month, now.day, 0, 0, 0)
     ref_timestamp_past_a_week = format_ref_date - diff_from_ref_day_plus_a_week
     return Decimal(ref_timestamp_past_a_week.timestamp())
+
+
+def calc_nas_ranking_this_week():
+    ref_timestamp = get_ref_timestamp()
+    nas_records = scan_nas_records(ref_timestamp)
+
+    if nas_records == []:
+        return {}
+
+    receive_user_list = []
+    for item in nas_records:
+        receive_user_list.append(item['receive_user_name'])
+
+    ranking_source = Counter(receive_user_list)
+    receive_users, nas_counts = zip(*ranking_source.most_common())
+    return dict(zip(receive_users, nas_counts))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import sys
 import time
+from datetime import datetime
+from decimal import Decimal
 
-from src.utils import get_last_week_ref_timestamp, get_ref_timestamp
+from src.utils import get_last_week_ref_timestamp, get_ref_timestamp, calc_nas_ranking_this_week
 
 sys.path.append('../')
 
@@ -42,3 +44,51 @@ def test_get_last_week_ref_timestamp():
     time.sleep(1)
     ref_timestamp_2 = get_last_week_ref_timestamp()
     assert ref_timestamp_1 == ref_timestamp_2
+
+
+def test_calc_nas_ranking_this_week(nas_db):
+    """Create a NAS ranking from a NAS record
+    Get the ranking of those who received NAS from NAS records scanned from dynamo db.
+    scan_nas_records() is used for the scan of dynamo db.
+
+    Returns:
+        dict : nas ranking data
+    """
+
+    estimate_nas_ranking = {}
+    assert calc_nas_ranking_this_week() == {}
+
+    for i in range(3):
+        now = datetime.now()
+        nas = {
+            'tip_user_id': 'test_user_A_id',
+            'time_stamp': Decimal(now.timestamp()),
+            'receive_user_id': 'test_user_B_id',
+            'receive_user_name': 'test_user_B_name',
+            'tip_type': 'stamp',
+            'tip_user_name': 'test_user_A_name',
+            'team_id': 'test_team_id'
+        }
+        nas_db.put_item(Item=nas)
+    estimate_nas_ranking = {
+        'test_user_B_name': 3
+    }
+    assert calc_nas_ranking_this_week() == estimate_nas_ranking
+
+    for i in range(2):
+        now = datetime.now()
+        nas = {
+            'tip_user_id': 'test_user_A_id',
+            'time_stamp': Decimal(now.timestamp()),
+            'receive_user_id': 'test_user_C_id',
+            'receive_user_name': 'test_user_C_name',
+            'tip_type': 'stamp',
+            'tip_user_name': 'test_user_A_name',
+            'team_id': 'test_team_id'
+        }
+        nas_db.put_item(Item=nas)
+    estimate_nas_ranking = {
+        'test_user_B_name': 3,
+        'test_user_C_name': 2
+    }
+    assert calc_nas_ranking_this_week() == estimate_nas_ranking


### PR DESCRIPTION
## Purpose
Implement the NAS ranking.
Retrieve all data from the DYNAMO DB for a given period of time and create a ranking of users who received the NAS.

When doing scan in dynamo db, be careful because the behavior is a little special.

## How to implement
Scan the dynamo db and count it with Counter.

## Test trail
- [x] can get record using scan from dynamo db
- [x] calculate ranking from nas record source

## reference
