### PR TITLE
20200428 add nas gacha

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ env =
     NAS_LIMIT = 30
     SLACK_BOT_USER_ACCESS_TOKEN = sample_bot_token
     SLACK_OAUTH_ACCESS_TOKEN = sample_oauth_token
+    NAS_GACHA_COST = 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,4 @@ env =
     SLACK_BOT_USER_ACCESS_TOKEN = sample_bot_token
     SLACK_OAUTH_ACCESS_TOKEN = sample_oauth_token
     NAS_GACHA_COST = 10
+    GACHA_WIN_RATE = 0.1

--- a/src/db.py
+++ b/src/db.py
@@ -62,3 +62,23 @@ def create_nas_record(nas_user_id, nas_user_name, receive_user_id, receive_user_
     except Exception as e:
         print(e)
         return False
+
+
+def create_nas_gacha_record(gacha_user_id, time_stamp, has_nas_num, used_nas_num, has_tickets):
+    try:
+        dynamoDB = boto3.resource('dynamodb')
+        nas_gacha_table = dynamoDB.Table('NAS_GACHA')
+
+        nas_gacha_table.put_item(
+            Item={
+                'user_id': gacha_user_id,
+                'time_stamp': time_stamp,
+                'has_nas_num': has_nas_num,
+                'used_nas_num': used_nas_num,
+                'has_tickets': has_tickets
+            }
+        )
+        return True
+    except Exception as e:
+        print(e)
+        return False

--- a/src/db.py
+++ b/src/db.py
@@ -64,6 +64,29 @@ def create_nas_record(nas_user_id, nas_user_name, receive_user_id, receive_user_
         return False
 
 
+def scan_user_receive_nas_num(scan_user_id):
+    try:
+        dynamoDB = boto3.resource('dynamodb')
+        table = dynamoDB.Table('NAS')
+
+        response = table.scan(
+            FilterExpression=Key('receive_user_id').eq(scan_user_id)
+        )
+        nas_records = response['Items']
+
+        while 'LastEvaluatedKey' in response:
+            response = table.scan(
+                FilterExpression=Key('receive_user_id').eq(scan_user_id),
+                ExclusiveStartKey=response['LastEvaluatedKey']
+            )
+            nas_records.extend(response['Items'])
+
+        return len(nas_records)
+    except Exception as e:
+        print(e)
+        return 0
+
+
 def load_latest_nas_gacha_record(gacha_user_id):
     try:
         dynamoDB = boto3.resource('dynamodb')

--- a/src/db.py
+++ b/src/db.py
@@ -64,6 +64,25 @@ def create_nas_record(nas_user_id, nas_user_name, receive_user_id, receive_user_
         return False
 
 
+def load_latest_nas_gacha_record(gacha_user_id):
+    try:
+        dynamoDB = boto3.resource('dynamodb')
+        table = dynamoDB.Table('NAS_GACHA')
+
+        nas_gacha_records = table.query(
+            KeyConditionExpression=Key('user_id').eq(gacha_user_id)
+        )
+
+        latest_nas_record = max(nas_gacha_records["Items"], key=(lambda x: x["time_stamp"]))
+        print(latest_nas_record)
+        print(type(latest_nas_record))
+
+        return latest_nas_record
+    except Exception as e:
+        print(e)
+        return {}
+
+
 def create_nas_gacha_record(gacha_user_id, time_stamp, has_nas_num, used_nas_num, has_tickets):
     try:
         dynamoDB = boto3.resource('dynamodb')

--- a/src/gacha.py
+++ b/src/gacha.py
@@ -1,0 +1,9 @@
+import os
+import numpy as np
+
+GACHA_WIN_RATE = os.environ['GACHA_WIN_RATE']
+
+
+def select_prize():
+    prizes = ['prize_1', 'prize_2', 'prize_3', 'prize_4', 'prize_5']
+    return np.random.choice(prizes)

--- a/src/gacha.py
+++ b/src/gacha.py
@@ -1,9 +1,19 @@
 import os
 import numpy as np
+from random import random
 
-GACHA_WIN_RATE = os.environ['GACHA_WIN_RATE']
+GACHA_WIN_RATE = float(os.environ['GACHA_WIN_RATE'])
 
 
 def select_prize():
     prizes = ['prize_1', 'prize_2', 'prize_3', 'prize_4', 'prize_5']
     return np.random.choice(prizes)
+
+
+def roll_a_gacha():
+    roll_a_rate = random()
+    if roll_a_rate > (1-GACHA_WIN_RATE):
+        prize = select_prize()
+        return prize
+
+    return ''

--- a/src/nas.py
+++ b/src/nas.py
@@ -1,14 +1,16 @@
 # nasクラスを作る。
 import math
 import os
+from decimal import Decimal
+from datetime import datetime
 from configparser import ConfigParser, ExtendedInterpolation
 
-from .db import create_nas_record, load_send_nas_num, scan_user_receive_nas_num, load_latest_nas_gacha_record
+from .db import create_nas_record, load_send_nas_num, scan_user_receive_nas_num, load_latest_nas_gacha_record, create_nas_gacha_record
 from .utils import get_last_week_ref_timestamp, get_ref_timestamp
+from .gacha import roll_a_gacha
 
 STAMP_CONFIG = ConfigParser(interpolation=ExtendedInterpolation())
 STAMP_CONFIG.read('./src/stamp_config.ini')
-
 
 NAS_LIMIT = int(os.environ['NAS_LIMIT'])
 NAS_GACHA_COST = int(os.environ['NAS_GACHA_COST'])
@@ -89,4 +91,27 @@ class Nas:
             print(all_receive_nas_num)
             return False
 
+        return True
+
+    def nas_gacha(self):
+        if self.check_can_run_gacha() is False:
+            return False
+
+        now = datetime.now()
+        all_receive_nas_num = scan_user_receive_nas_num(self.user_id)
+        latest_nas_gacha_record = load_latest_nas_gacha_record(self.user_id)
+
+        gacha_result = roll_a_gacha()
+        if latest_nas_gacha_record == {}:
+            already_used_nas_num = 0
+            has_tickets = {}
+            if gacha_result != '':
+                has_tickets[gacha_result] = 1
+        else:
+            already_used_nas_num = int(latest_nas_gacha_record['used_nas_num']) + NAS_GACHA_COST
+            has_tickets = latest_nas_gacha_record['has_tickets']
+            if gacha_result != '':
+                has_tickets[gacha_result] = has_tickets.get(gacha_result, 0) + 1
+
+        create_nas_gacha_record(self.user_id, Decimal(now.timestamp()), all_receive_nas_num, already_used_nas_num, has_tickets)
         return True

--- a/src/nas.py
+++ b/src/nas.py
@@ -3,7 +3,7 @@ import math
 import os
 from configparser import ConfigParser, ExtendedInterpolation
 
-from .db import create_nas_record, load_send_nas_num
+from .db import create_nas_record, load_send_nas_num, scan_user_receive_nas_num, load_latest_nas_gacha_record
 from .utils import get_last_week_ref_timestamp, get_ref_timestamp
 
 STAMP_CONFIG = ConfigParser(interpolation=ExtendedInterpolation())
@@ -11,6 +11,7 @@ STAMP_CONFIG.read('./src/stamp_config.ini')
 
 
 NAS_LIMIT = int(os.environ['NAS_LIMIT'])
+NAS_GACHA_COST = int(os.environ['NAS_GACHA_COST'])
 
 
 class Nas:
@@ -75,4 +76,17 @@ class Nas:
             return False
 
         create_nas_record(self.user_id, self.user_name, receive_user_id, receive_user_name, 'message', self.team_id)
+        return True
+
+    def check_can_run_gacha(self):
+        all_receive_nas_num = scan_user_receive_nas_num(self.user_id)
+        latest_nas_gacha_record = load_latest_nas_gacha_record(self.user_id)
+        if latest_nas_gacha_record == {}:
+            return True
+        already_used_nas_num = int(latest_nas_gacha_record['used_nas_num']) + NAS_GACHA_COST
+
+        if already_used_nas_num >= all_receive_nas_num:
+            print(all_receive_nas_num)
+            return False
+
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,3 +40,40 @@ def nas_db():
 
         nas_db = dynamoDB.Table('NAS')
         yield nas_db
+
+
+@pytest.fixture
+def nas_gacha_db():
+    with mock_dynamodb2():
+        os.environ['AWS_DEFAULT_REGION'] = 'ap-northeast-1'
+        dynamoDB = boto3.resource('dynamodb')
+        dynamoDB.create_table(
+            TableName='NAS_GACHA',
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'user_id',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'time_stamp',
+                    'AttributeType': 'N'
+                }
+            ],
+            KeySchema=[
+                {
+                    'AttributeName': 'user_id',
+                    'KeyType': 'HASH'
+                },
+                {
+                    'AttributeName': 'time_stamp',
+                    'KeyType': 'RANGE'
+                },
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 5,
+                'WriteCapacityUnits': 5,
+            }
+        )
+
+        nas_gacha_db = dynamoDB.Table('NAS_GACHA')
+        yield nas_gacha_db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,21 +53,13 @@ def nas_gacha_db():
                 {
                     'AttributeName': 'user_id',
                     'AttributeType': 'S'
-                },
-                {
-                    'AttributeName': 'time_stamp',
-                    'AttributeType': 'N'
                 }
             ],
             KeySchema=[
                 {
                     'AttributeName': 'user_id',
                     'KeyType': 'HASH'
-                },
-                {
-                    'AttributeName': 'time_stamp',
-                    'KeyType': 'RANGE'
-                },
+                }
             ],
             ProvisionedThroughput={
                 'ReadCapacityUnits': 5,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,7 +3,7 @@ import sys
 from datetime import datetime
 from decimal import Decimal
 
-from src.db import create_nas_record, load_send_nas_num, scan_nas_records, create_nas_gacha_record
+from src.db import create_nas_record, load_send_nas_num, scan_nas_records, create_nas_gacha_record, load_latest_nas_gacha_record
 from src.utils import get_ref_timestamp
 
 sys.path.append('../')
@@ -94,6 +94,45 @@ def test_create_nas_record(nas_db):
     assert load_send_nas_num('test_user_A_id', ref_timestamp) == 1
 
     assert load_send_nas_num('test_user_B_id', ref_timestamp) == 0
+
+
+def test_load_latest_nas_gacha_record(nas_gacha_db):
+    """Retrieve the latest record of the target user.
+    The user record in nas_gacha is the most recent record representing the most recent state.
+    Along with that, when creating a new record or wanting to know the status of the user,
+    it is necessary to get the latest record.
+    This function does not return the contents of the record, but gets all the latest records.
+
+    Args:
+        gacha_user_id : The id of the user who wants to retrieve the latest record.
+
+    Return:
+        dict : latest record.
+    """
+
+    assert load_latest_nas_gacha_record('test_user_A_id') == {}
+
+    now = datetime.now()
+    create_nas_gacha_record('test_user_A_id', Decimal(now.timestamp()), 10, 0, {})
+    nas_gacha_record = {
+        'user_id': 'test_user_A_id',
+        'time_stamp': Decimal(now.timestamp()),
+        'has_nas_num': 10,
+        'used_nas_num': 0,
+        'has_tickets': {}
+    }
+    assert load_latest_nas_gacha_record('test_user_A_id') == nas_gacha_record
+
+    now = datetime.now()
+    create_nas_gacha_record('test_user_A_id', Decimal(now.timestamp()), 0, 10, {})
+    nas_gacha_record = {
+        'user_id': 'test_user_A_id',
+        'time_stamp': Decimal(now.timestamp()),
+        'has_nas_num': 0,
+        'used_nas_num': 10,
+        'has_tickets': {}
+    }
+    assert load_latest_nas_gacha_record('test_user_A_id') == nas_gacha_record
 
 
 def test_create_nas_gacha_record(nas_gacha_db):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,7 +3,8 @@ import sys
 from datetime import datetime
 from decimal import Decimal
 
-from src.db import create_nas_record, load_send_nas_num, scan_nas_records, create_nas_gacha_record, load_latest_nas_gacha_record
+from src.db import create_nas_record, load_send_nas_num, scan_nas_records, \
+    create_nas_gacha_record, load_latest_nas_gacha_record, scan_user_receive_nas_num
 from src.utils import get_ref_timestamp
 
 sys.path.append('../')
@@ -94,6 +95,28 @@ def test_create_nas_record(nas_db):
     assert load_send_nas_num('test_user_A_id', ref_timestamp) == 1
 
     assert load_send_nas_num('test_user_B_id', ref_timestamp) == 0
+
+
+def test_scan_user_receive_nas_num(nas_db):
+    """Aggregate all the NAS the user has received so far.
+    Aggregate all the NASs that have been received from other users so far.
+    It doesn't use what's on the record.
+    Returns the number of records sent to you.
+    You can't use query, so you can use scan.
+
+    Args:
+        scan_user_id: target user slack id
+
+    Return:
+        int: receive nas sum
+    """
+    assert scan_user_receive_nas_num('test_user_B_id') == 0
+    create_nas_record('test_user_A_id', 'test_user_A_name', 'test_user_B_id', 'test_user_B_name', 'stamp', 'test_team_id')
+    assert scan_user_receive_nas_num('test_user_B_id') == 1
+    create_nas_record('test_user_A_id', 'test_user_A_name', 'test_user_B_id', 'test_user_B_name', 'stamp', 'test_team_id')
+    create_nas_record('test_user_A_id', 'test_user_A_name', 'test_user_B_id', 'test_user_B_name', 'stamp', 'test_team_id')
+    assert scan_user_receive_nas_num('test_user_A_id') == 0
+    assert scan_user_receive_nas_num('test_user_B_id') == 3
 
 
 def test_load_latest_nas_gacha_record(nas_gacha_db):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,7 +3,7 @@ import sys
 from datetime import datetime
 from decimal import Decimal
 
-from src.db import create_nas_record, load_send_nas_num, scan_nas_records
+from src.db import create_nas_record, load_send_nas_num, scan_nas_records, create_nas_gacha_record
 from src.utils import get_ref_timestamp
 
 sys.path.append('../')
@@ -94,3 +94,21 @@ def test_create_nas_record(nas_db):
     assert load_send_nas_num('test_user_A_id', ref_timestamp) == 1
 
     assert load_send_nas_num('test_user_B_id', ref_timestamp) == 0
+
+
+def test_create_nas_gacha_record(nas_gacha_db):
+    """Create a nas_gacha record
+    The ability to turn the Gacha using the NAS you received.
+    A record is created each time, and the latest record of the target user indicates the current status.
+    Using a dynamo db called NAS_GACHA, which is separate from NAS.
+    Each gacha prize is saved in dictionary format.
+
+    Args:
+        gacha_user_id: executed nas gacha user id
+        time_stamp: the record created time stamp.
+        has_nas_num: Total value of the NAS we received.
+        used_nas_num: Already used nas for gacha.
+        has_tickets: The list of freebies that the user has at that time.
+    """
+    now = datetime.now()
+    assert create_nas_gacha_record('test_user_A_id', Decimal(now.timestamp()), 10, 0, {}) is True

--- a/tests/test_gacha.py
+++ b/tests/test_gacha.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from src.gacha import select_prize
+from src.gacha import select_prize, roll_a_gacha
 
 sys.path.append('../')
 
@@ -17,3 +17,15 @@ def test_select_prize():
     """
     prizes = ['prize_1', 'prize_2', 'prize_3', 'prize_4', 'prize_5']
     assert select_prize() in prizes
+
+def test_roll_a_gacha():
+    """Gacha spinning function
+    Turn the gacha based on a predetermined probability.
+    If the prize is won, the prize is determined by the select_prize() function.
+    It's just a matter of turning the gacha. Record writing, etc. is done by another function.
+
+    Return:
+        str: hit prize name
+    """
+    prizes_and_empty = ['prize_1', 'prize_2', 'prize_3', 'prize_4', 'prize_5', '']
+    assert roll_a_gacha() in prizes_and_empty

--- a/tests/test_gacha.py
+++ b/tests/test_gacha.py
@@ -18,6 +18,7 @@ def test_select_prize():
     prizes = ['prize_1', 'prize_2', 'prize_3', 'prize_4', 'prize_5']
     assert select_prize() in prizes
 
+
 def test_roll_a_gacha():
     """Gacha spinning function
     Turn the gacha based on a predetermined probability.

--- a/tests/test_gacha.py
+++ b/tests/test_gacha.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import sys
+
+from src.gacha import select_prize
+
+sys.path.append('../')
+
+
+def test_select_prize():
+    """Functions for determining gacha prizes
+    If you win the gacha, one of the prizes will be selected at random from the set prizes.
+    The giveaway is defined in the function.
+    I'd really like to cut it out somewhere, but it's too delicate to move it, so I'm writing it here.
+
+    Return:
+        str: hit prize name
+    """
+    prizes = ['prize_1', 'prize_2', 'prize_3', 'prize_4', 'prize_5']
+    assert select_prize() in prizes

--- a/tests/test_nas.py
+++ b/tests/test_nas.py
@@ -270,3 +270,13 @@ class TestNas():
             }
             nas_db.put_item(Item=nas_item)
         assert nas_obj_A.check_can_run_gacha() is True
+
+    def test_nas_gacha(self, nas_gacha_db):
+        """Function to roll Gacha and write the result
+        This function is used when the Gacha command is executed.
+        Gacha is designed so that the first time you play it, it's free.
+        The cost of one turn is 10 NAS received from someone else.
+        If you want to roll a gacha, you'll need to get an NAS from someone else.
+        """
+        nas_obj_A = Nas('test_user_A_id', 'test_user_A_name', 'test_team_id')
+        assert nas_obj_A.nas_gacha() is True

--- a/tests/test_nas.py
+++ b/tests/test_nas.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import os
 import sys
+import boto3
 from datetime import datetime, timedelta
 from decimal import Decimal
 
@@ -183,3 +185,88 @@ class TestNas():
         assert nas_obj.nas_message('test_user_B_id', 'test_user_B_name') is True
 
         assert nas_obj.nas_message('test_user_A_id', 'test_user_A_name') is False
+
+    def test_check_can_run_gacha(self, nas_gacha_db):
+        """Check to see if the gacha is available
+        The NAS takes 10 NAS to pull one time.
+        Use the NAS you've received so far.
+        Gacha costs 10 pieces by default to pull once.
+        Calculate that amount and check if you can roll the gacha.
+        The first time (when there is no nas_gacha record), it is always possible to draw once.
+
+        Returns:
+            bool: available is True. unavailable is False.
+        """
+        nas_obj_A = Nas('test_user_A_id', 'test_user_A_name', 'test_team_id')
+
+        # setup nas_db
+        os.environ['AWS_DEFAULT_REGION'] = 'ap-northeast-1'
+        dynamoDB = boto3.resource('dynamodb')
+        dynamoDB.create_table(
+            TableName='NAS',
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'tip_user_id',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'time_stamp',
+                    'AttributeType': 'N'
+                }
+            ],
+            KeySchema=[
+                {
+                    'AttributeName': 'tip_user_id',
+                    'KeyType': 'HASH'
+                },
+                {
+                    'AttributeName': 'time_stamp',
+                    'KeyType': 'RANGE'
+                },
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 15,
+                'WriteCapacityUnits': 5,
+            }
+        )
+
+        nas_db = dynamoDB.Table('NAS')
+        assert nas_obj_A.check_can_run_gacha() is True
+
+        now = datetime.now()
+        nas_gacha_item = {
+            'user_id': 'test_user_A_id',
+            'time_stamp': Decimal(now.timestamp()),
+            'has_nas_num': 10,
+            'used_nas_num': 0,
+            'has_tickets': {}
+        }
+        nas_gacha_db.put_item(Item=nas_gacha_item)
+        assert nas_obj_A.check_can_run_gacha() is False
+
+        now = datetime.now()
+        nas_item = {
+            'tip_user_id': 'test_user_B_id',
+            'time_stamp': Decimal(now.timestamp()),
+            'receive_user_id': 'test_user_A_id',
+            'receive_user_name': 'test_user_A_name',
+            'tip_type': 'stamp',
+            'tip_user_name': 'test_user_B_name',
+            'team_id': 'test_team_id'
+        }
+        nas_db.put_item(Item=nas_item)
+        assert nas_obj_A.check_can_run_gacha() is False
+
+        for i in range(10):
+            now = datetime.now()
+            nas_item = {
+                'tip_user_id': 'test_user_B_id',
+                'time_stamp': Decimal(now.timestamp()),
+                'receive_user_id': 'test_user_A_id',
+                'receive_user_name': 'test_user_A_name',
+                'tip_type': 'stamp',
+                'tip_user_name': 'test_user_B_name',
+                'team_id': 'test_team_id'
+            }
+            nas_db.put_item(Item=nas_item)
+        assert nas_obj_A.check_can_run_gacha() is True


### PR DESCRIPTION
## Purpose
Add a gacha feature to your NAS

The gacha can be turned using the NAS you got.
It takes 10 NAS to turn one.
However, the first time around, it's free.

If you win, you will be awarded a prize from among the tickets.

We are working on a system to process the tickets.

## How to implement
- implement gacha

## Test trail
- [x] can load all receive nas
- [x] can check nas_gacha available
- [x] can create nas_gacha record
- [x] can roll a gacha

## reference
